### PR TITLE
restoring (accidentally lost) datavault predictor api changes - neede…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -116,16 +116,16 @@ asynchronous job status.
 
 Example:
 ```
-predict = ILabsDatavaultPredictor.init(domain='embase-indexing', collection='my-collection')
+predictor = ILabsDatavaultPredictor.init(domain='embase-indexing', collection='my-collection')
 
 document = b'''{"title":"Unlock the power of your digital data", "abstract": "Innodata is a global
 services and technology solutions company. We combine data extraction, machine learning, and data
 enrichment with domain expertise to help you transform your business, drive new revenue, and get
 to market faster with your products and services."}'''
 
-prediction = predict(document, progress=print)
+prediction = predictor(document, progress=print)
 
 # Uploading feedback data
-predict.upload(prediction, name='feedback.txt', facet='feedback')
+predictor.upload(prediction, name='feedback.txt', facet='feedback')
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,25 +116,18 @@ asynchronous job status.
 
 Example:
 ```
-api = ILabsApi()
-datavault_api = ILabsDatavaultApi()
-predict = ILabsDatavaultPredictor(api, datavault_api, domain='embase-indexing')
+predict = ILabsDatavaultPredictor.init(domain='embase-indexing', collection='my-collection')
 
 document = b'''{"title":"Unlock the power of your digital data", "abstract": "Innodata is a global
 services and technology solutions company. We combine data extraction, machine learning, and data
 enrichment with domain expertise to help you transform your business, drive new revenue, and get
 to market faster with your products and services."}'''
 
-prediction = predict(document
-                     collection='my-collection',
-                     filename='my-document.json',
-                     input_facet='master',
-                     output_facet='prediction',
-                     progress=print)
+prediction = predict(document, progress=print)
 
 # Uploading feedback data
 predict.upload_feedback(prediction,
-                        collection='my-collection'
+                        name='feedback.txt'
                         facet='feedback')
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,8 +126,6 @@ to market faster with your products and services."}'''
 prediction = predict(document, progress=print)
 
 # Uploading feedback data
-predict.upload_feedback(prediction,
-                        name='feedback.txt'
-                        facet='feedback')
+predict.upload(prediction, name='feedback.txt', facet='feedback')
 
 ```

--- a/ilabs/client/__init__.py
+++ b/ilabs/client/__init__.py
@@ -1,4 +1,4 @@
-__version__      = '0.2.6'
+__version__      = '0.3.0'
 __url__          = 'https://github.com/innodatalabs/ilabs.client'
 __author__       = 'Mike Kroutikov'
 __author_email__ = 'mkroutikov@innodata.com'

--- a/ilabs/client/ilabs_api.py
+++ b/ilabs/client/ilabs_api.py
@@ -24,9 +24,10 @@ class ILabsApi:
         self.URL_FEEDBACK = self.URL_API_BASE + '/documents/training/{domain}/'
 
         self.URL_PREDICT  = self.URL_API_BASE + '/reference/{domain}/{name}'
-        self.URL_PREDICT_DATAVAULT = self.URL_API_BASE + '/prediction/{domain}/{collection}/{name}'
         self.URL_STATUS   = self.URL_API_BASE + '/reference/{domain}/{task_id}/status'
         self.URL_CANCEL   = self.URL_API_BASE + '/reference/{domain}/{task_id}/cancel'
+
+        self.URL_PREDICT_DV  = self.URL_API_BASE + '/prediction/{domain}/{collection}/{name}'
 
         self._user_key = user_key or get_secret().get('ilabs_user_key')
         if self._user_key is None:
@@ -58,13 +59,13 @@ class ILabsApi:
     def _post(self, url, data, content_type=None, query=None):
         return self._request('POST', url, data, content_type=content_type, query=query)
 
-    def get(self, url):
+    def get(self, url, query=None):
         '''
         Issues GET request with credentials.
         Useful for status/ and cancel/ REST operations using
         urls returned from predict() call.
         '''
-        return self._request('GET', url)
+        return self._request('GET', url, query=query)
 
     def ping(self):
         '''
@@ -134,11 +135,10 @@ class ILabsApi:
         out = self.get(url)
         return json.loads(out.decode())
 
-    def predict_from_datavault(self, domain, collection, filename,
-        input_facet='master', output_facet='prediction'):
+    def predict_dv(self, domain, collection, filename, input_facet='input', output_facet='output'):
         '''
-        Schedules a task to run prediction on file "filename" inside
-        facet "input_facet" in collection "collection" using domain "domain".
+        Schedules a task to run prediction on file "filename" using
+        domain "domain".
 
         Returns dictionary with the following keys:
 
@@ -149,21 +149,18 @@ class ILabsApi:
         - output_filename - name of the output file (created only after task
             successfully completes)
         '''
+        logging.info('Trigger prediction job from Datavault: domain=%s, name=%s/%s, input_facet=%s, output_facet=%s',
+            domain, collection, filename, input_facet, output_facet)
 
-        logging.info('Trigger prediction job: domain=%s, collection=%s, filename=%s',
-            domain, collection, filename)
         validate_filename(filename)
-        url = self.URL_PREDICT_DATAVAULT.format(
+        url = self.URL_PREDICT_DV.format(
             domain=domain,
             collection=collection,
             name=filename)
-
-        query = {
+        out = self._post(url, b'', query={
             'input_facet': input_facet,
             'output_facet': output_facet
-        }
-
-        out = self._post(url, data=b'', query=query)
+        })
         return json.loads(out.decode())
 
     def status(self, domain, task_id):

--- a/ilabs/client/ilabs_api.py
+++ b/ilabs/client/ilabs_api.py
@@ -135,7 +135,7 @@ class ILabsApi:
         out = self.get(url)
         return json.loads(out.decode())
 
-    def predict_dv(self, domain, collection, filename, input_facet='input', output_facet='output'):
+    def predict_from_datavault(self, domain, collection, filename, input_facet='master', output_facet='prediction'):
         '''
         Schedules a task to run prediction on file "filename" using
         domain "domain".

--- a/ilabs/client/ilabs_datavault_api.py
+++ b/ilabs/client/ilabs_datavault_api.py
@@ -124,7 +124,7 @@ class ILabsDatavaultApi:
         return json.loads(out.decode())['count']
 
     def upload(self, binary_data, collection, name, facet='master'):
-        out = self._post('/' + collection + '/' + name + '/' + facet, data=binary_data, content_type='application/octet-stream')
+        self._post('/' + collection + '/' + name + '/' + facet, data=binary_data, content_type='application/octet-stream')
 
     def download(self, collection, name, facet='master'):
         return self._get('/' + collection + '/' + name + '/' + facet)

--- a/ilabs/client/ilabs_datavault_bulk_predict.py
+++ b/ilabs/client/ilabs_datavault_bulk_predict.py
@@ -20,16 +20,6 @@ def predict(input_filename, output_filename, predictor):
         return e
 
 
-def _create_collection_if_needed(collection, api):
-    present_collections = api.list_collections()
-    if collection not in present_collections:
-        api.create_collection(collection)
-        policy = api.get_collection_policy(collection)
-        policy['grants'] = {'api.innodatalabs.com': ['write']}
-        api.set_collection_policy(collection, policy)
-        print('Created an empty collection %s' % collection)
-
-
 def bulk_predict(
     domain,
     input,
@@ -80,7 +70,6 @@ def bulk_predict(
         error = predict(
             os.path.join(input, fname),
             os.path.join(output, fname),
-            collection,
             predictor
         )
 

--- a/ilabs/client/ilabs_datavault_predictor.py
+++ b/ilabs/client/ilabs_datavault_predictor.py
@@ -27,6 +27,7 @@ class ILabsDatavaultPredictor(ilabs_api.ILabsApi):
         self._collection = collection
         self._input_facet=input_facet
         self._output_facet=output_facet
+        self._create_collection_if_needed()
 
     def __call__(self, binary_data, name=None, progress=None):
         if progress is None:
@@ -89,3 +90,12 @@ class ILabsDatavaultPredictor(ilabs_api.ILabsApi):
 
     def download(self, name, facet='master'):
         return self._datavault.download(self._collection, name, facet=facet)
+
+    def _create_collection_if_needed(self):
+        present_collections = self._datavault.list_collections()
+        if self._collection not in present_collections:
+            self._datavault.create_collection(self._collection)
+            policy = self._datavault.get_collection_policy(self._collection)
+            policy['grants'] = {'api.innodatalabs.com': ['write']}
+            self._datavault.set_collection_policy(self._collection, policy)
+            progress('Created an empty collection %s' % self._collection)

--- a/ilabs/client/ilabs_datavault_predictor.py
+++ b/ilabs/client/ilabs_datavault_predictor.py
@@ -98,4 +98,3 @@ class ILabsDatavaultPredictor(ilabs_api.ILabsApi):
             policy = self._datavault.get_collection_policy(self._collection)
             policy['grants'] = {'api.innodatalabs.com': ['write']}
             self._datavault.set_collection_policy(self._collection, policy)
-            progress('Created an empty collection %s' % self._collection)

--- a/ilabs/client/ilabs_datavault_predictor.py
+++ b/ilabs/client/ilabs_datavault_predictor.py
@@ -1,35 +1,53 @@
-import os
+from ilabs.client import ilabs_api, ilabs_datavault_api
 import time
 import json
 import logging
-
+import uuid
 
 def noop(*av, **kav): pass
 
-class ILabsDatavaultPredictor:
 
-    def __init__(self, api, datavault_api, domain):
+class ILabsDatavaultPredictor(ilabs_api.ILabsApi):
+
+    @classmethod
+    def init(cls, domain, collection, input_facet='input', output_facet='output', user_key=None, datavault_key=None, timeout=None, user_agent=None):
+        return cls(
+            ilabs_api.ILabsApi(user_key=user_key, timeout=timeout, user_agent=user_agent),
+            ilabs_datavault_api.ILabsDatavaultApi(user_key=user_key, datavault_key=datavault_key, timeout=timeout, user_agent=user_agent),
+            domain=domain,
+            collection=collection,
+            input_facet=input_facet,
+            output_facet=output_facet
+        )
+
+    def __init__(self, api, datavault, domain, collection, input_facet='input', output_facet='output'):
         self.api = api
-        self.datavault_api = datavault_api
+        self._datavault = datavault
         self._domain = domain
+        self._collection = collection
+        self._input_facet=input_facet
+        self._output_facet=output_facet
 
-    def __call__(self, binary_data, collection, filename, input_facet='master',
-                    output_facet='prediction', progress=None):
-
+    def __call__(self, binary_data, name=None, progress=None):
         if progress is None:
             progress = noop
 
-        progress('Uploading document %s in %s/%s' % (filename, collection, input_facet))
-        out = self.datavault_api.upload(binary_data, collection, filename, facet=input_facet)
-        response = self.api.predict_from_datavault(self._domain, collection, filename,
-            input_facet=input_facet, output_facet=output_facet)
+        if name is None:
+            name = str(uuid.uuid4())
 
+        progress('uploading %s bytes' % len(binary_data))
+
+        self.upload(binary_data, name, facet=self._input_facet)
+
+        progress('uploaded')
+
+        response = self.api.predict_dv(self._domain, self._collection, name, input_facet=self._input_facet, output_facet=self._output_facet)
         task_id = response['task_id']
         task_cancel_url = response['task_cancel_url']
         document_output_url = response['document_output_url']
         task_status_url = response['task_status_url']
         output_filename = response['output_filename']
-        progress('Job submitted, task id: %s' % task_id)
+        progress('job submitted, taks id: %s' % task_id)
 
         try:
             count = 1
@@ -59,12 +77,15 @@ class ILabsDatavaultPredictor:
         if err is not None:
             raise RuntimeError('Prediction server returned error: ' + err)
 
-        progress('Fetching result')
-        progress('Downloading document %s from %s/%s' % (filename, collection, output_facet))
-        prediction = self.datavault_api.download(collection, filename, facet=output_facet)
-        progress('Downloaded %s bytes' % len(prediction))
+        progress('fetching result')
+        logging.info('Downloading from: %s', document_output_url)
+        prediction = self.download(name, facet=self._output_facet)
+        progress('downloaded %s bytes' % len(prediction))
 
         return prediction
 
-    def upload_feedback(self, binary_data, collection, filename, facet='feedback'):
-        out = self.datavault_api.upload(binary_data, collection, filename, facet=facet)
+    def upload(self, binary_data, name, facet='master'):
+        self._datavault.upload(binary_data, self._collection, name, facet=facet)
+
+    def download(self, name, facet='master'):
+        return self._datavault.download(self._collection, name, facet=facet)

--- a/ilabs/client/ilabs_datavault_predictor.py
+++ b/ilabs/client/ilabs_datavault_predictor.py
@@ -27,7 +27,6 @@ class ILabsDatavaultPredictor(ilabs_api.ILabsApi):
         self._collection = collection
         self._input_facet=input_facet
         self._output_facet=output_facet
-        self._create_collection_if_needed()
 
     def __call__(self, binary_data, name=None, progress=None):
         if progress is None:
@@ -91,10 +90,7 @@ class ILabsDatavaultPredictor(ilabs_api.ILabsApi):
     def download(self, name, facet='master'):
         return self._datavault.download(self._collection, name, facet=facet)
 
-    def _create_collection_if_needed(self):
-        present_collections = self._datavault.list_collections()
-        if self._collection not in present_collections:
-            self._datavault.create_collection(self._collection)
-            policy = self._datavault.get_collection_policy(self._collection)
-            policy['grants'] = {'api.innodatalabs.com': ['write']}
-            self._datavault.set_collection_policy(self._collection, policy)
+    @property
+    def datavault_api(self):
+        return self._datavault
+

--- a/ilabs/client/ilabs_datavault_predictor.py
+++ b/ilabs/client/ilabs_datavault_predictor.py
@@ -41,7 +41,7 @@ class ILabsDatavaultPredictor(ilabs_api.ILabsApi):
 
         progress('uploaded')
 
-        response = self.api.predict_dv(self._domain, self._collection, name, input_facet=self._input_facet, output_facet=self._output_facet)
+        response = self.api.predict_from_datavault(self._domain, self._collection, name, input_facet=self._input_facet, output_facet=self._output_facet)
         task_id = response['task_id']
         task_cancel_url = response['task_cancel_url']
         document_output_url = response['document_output_url']

--- a/ilabs/client/test/test_get_secret.py
+++ b/ilabs/client/test/test_get_secret.py
@@ -49,7 +49,13 @@ class TestGetSecret(unittest.TestCase):
 
     def test_smoke(self):
         with mock.patch.dict(os.environ, {}):
-            user_key = get_secret().get('ilabs_user_key')
+            with mock.patch(
+                'ilabs.client.get_secret.configparser',
+                mock.Mock(ConfigParser=mock.Mock(return_value=mock.Mock(
+                    get=mock.Mock(return_value=None)
+                )))
+            ):
+                user_key = get_secret().get('ilabs_user_key')
 
         self.assertIsNone(user_key)
 
@@ -58,7 +64,7 @@ class TestGetSecret(unittest.TestCase):
         with mock.patch.dict(os.environ, {'ILABS_USER_KEY': 'blah'}):
             user_key = get_secret().get('ilabs_user_key')
 
-        self.assertEquals(user_key, 'blah')
+        self.assertEqual(user_key, 'blah')
 
     def test_file(self):
 
@@ -74,7 +80,7 @@ ilabs_user_key=foo
             with mock.patch.dict(os.environ, {}):
                 user_key = get_secret().get('ilabs_user_key')
 
-        self.assertEquals(user_key, 'foo')
+        self.assertEqual(user_key, 'foo')
 
     def test_section(self):
 
@@ -91,7 +97,7 @@ ilabs_user_key=boo
         })):
             user_key = get_secret().get('ilabs_user_key')
 
-        self.assertEquals(user_key, 'boo')
+        self.assertEqual(user_key, 'boo')
 
     def test_file_precedence(self):
 
@@ -111,14 +117,14 @@ ilabs_user_key=foo
         })):
             user_key = get_secret().get('ilabs_user_key')
 
-        self.assertEquals(user_key, 'bar')
+        self.assertEqual(user_key, 'bar')
 
     def test_datavault_env(self):
 
         with mock.patch.dict(os.environ, {'ILABS_DATAVAULT_KEY': 'blah'}):
             datavault_key = get_secret().get('ilabs_datavault_key')
 
-        self.assertEquals(datavault_key, 'blah')
+        self.assertEqual(datavault_key, 'blah')
 
     def test_datavault_file(self):
 
@@ -132,7 +138,7 @@ ilabs_datavault_key=foo
         })):
             datavault_key = get_secret().get('ilabs_datavault_key')
 
-        self.assertEquals(datavault_key, 'foo')
+        self.assertEqual(datavault_key, 'foo')
 
 
 if __name__ == '__main__':

--- a/ilabs/client/test/test_ilabs_api.py
+++ b/ilabs/client/test/test_ilabs_api.py
@@ -40,7 +40,7 @@ class TestIlabsApi(unittest.TestCase):
         api._request = mock.Mock(return_value=b'{ "ping": "pong" }')
 
         rc = api.ping()
-        api._request.assert_called_once_with('GET', 'https://api.innodatalabs.com/v1/ping')
+        api._request.assert_called_once_with('GET', 'https://api.innodatalabs.com/v1/ping', query=None)
 
         self.assertEqual(rc, {'ping': 'pong'})
 
@@ -73,7 +73,8 @@ class TestIlabsApi(unittest.TestCase):
         rc = api.download_input('XXX')
         api._request.assert_called_once_with(
             'GET',
-            'https://api.innodatalabs.com/v1/documents/input/XXX')
+            'https://api.innodatalabs.com/v1/documents/input/XXX',
+            query=None)
 
         self.assertEqual(rc, b'contents')
 
@@ -92,7 +93,8 @@ class TestIlabsApi(unittest.TestCase):
         rc = api.predict(domain='test-domain', filename='123456.bin')
         api._request.assert_called_once_with(
             'GET',
-            'https://api.innodatalabs.com/v1/reference/test-domain/123456.bin'
+            'https://api.innodatalabs.com/v1/reference/test-domain/123456.bin',
+            query=None
         )
 
         self.assertEqual(rc, {
@@ -132,7 +134,8 @@ class TestIlabsApi(unittest.TestCase):
         rc = api.status('test-domain', 'test-job-id')
         api._request.assert_called_once_with(
             'GET',
-            'https://api.innodatalabs.com/v1/reference/test-domain/test-job-id/status')
+            'https://api.innodatalabs.com/v1/reference/test-domain/test-job-id/status',
+            query=None)
 
         self.assertEqual(rc, {'completed': False})
 
@@ -143,7 +146,8 @@ class TestIlabsApi(unittest.TestCase):
         rc = api.cancel('test-domain', 'test-job-id')
         api._request.assert_called_once_with(
             'GET',
-            'https://api.innodatalabs.com/v1/reference/test-domain/test-job-id/cancel')
+            'https://api.innodatalabs.com/v1/reference/test-domain/test-job-id/cancel',
+            query=None)
 
         self.assertEqual(rc, [])
 

--- a/ilabs/client/test/test_ilabs_datavault_predictor.py
+++ b/ilabs/client/test/test_ilabs_datavault_predictor.py
@@ -10,8 +10,6 @@ _DUMMY_DATAVAULT_TOKEN = 'JWT0123456789'
 class TestIlabsDatavaultPredictor(unittest.TestCase):
 
     def test_prediction(self):
-        ilabs_datavault_predictor.ILabsDatavaultPredictor._create_collection_if_needed = mock.Mock()
-
         predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor.init(
             domain='foo-domain',
             collection='test-collection',
@@ -48,8 +46,6 @@ class TestIlabsDatavaultPredictor(unittest.TestCase):
         ])
 
     def test_feedback(self):
-        ilabs_datavault_predictor.ILabsDatavaultPredictor._create_collection_if_needed = mock.Mock()
-
         predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor.init(
             domain='foo-domain',
             collection='test-collection',

--- a/ilabs/client/test/test_ilabs_datavault_predictor.py
+++ b/ilabs/client/test/test_ilabs_datavault_predictor.py
@@ -10,44 +10,59 @@ _DUMMY_DATAVAULT_TOKEN = 'JWT0123456789'
 class TestIlabsDatavaultPredictor(unittest.TestCase):
 
     def test_prediction(self):
-        api = ilabs_api.ILabsApi(_DUMMY_USER_KEY)
-        api._request = mock.Mock(side_effect=[
+
+
+        predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor.init(
+            domain='foo-domain',
+            collection='test-collection',
+            user_key=_DUMMY_USER_KEY,
+            datavault_key=_DUMMY_DATAVAULT_TOKEN
+        )
+        predictor.api._request = mock.Mock(side_effect=[
             b'{ "task_id": "task-0", "task_cancel_url": "cancel", "document_output_url": "do", "task_status_url": "ts", "output_filename": "of"}',
             b'{ "completed": false, "progress": 1, "steps": 5 }',
             b'{ "completed": true, "progress": 5, "steps": 5 }',
         ])
-
-        datavault_api = ilabs_datavault_api.ILabsDatavaultApi(_DUMMY_USER_KEY, _DUMMY_DATAVAULT_TOKEN)
-        datavault_api._request = mock.Mock(side_effect=[
+        predictor._datavault._request = mock.Mock(side_effect=[
             b'',
             b'prediction'
         ])
 
-        predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor(api, datavault_api, domain='foo-domain')
         progress=mock.Mock()
-        rc = predictor(b'hello', 'test-collection', 'test.json', progress=progress)
-        self.assertEqual(api._request.call_count, 3)
-        self.assertEqual(datavault_api._request.call_count, 2)
+        rc = predictor(b'hello', name='test.json', progress=progress)
+        self.assertEqual(predictor.api._request.call_count, 3)
+        self.assertEqual(predictor._datavault._request.call_count, 2)
         self.assertEqual(rc, b'prediction')
         self.assertEqual(progress.call_count, 10)
         progress.assert_has_calls([
-            mock.call('Uploading document test.json in test-collection/master'),
-            mock.call('Job submitted, task id: task-0'),
+            mock.call('uploading 5 bytes'),
+            mock.call('uploaded'),
+            mock.call('job submitted, taks id: task-0'),
             mock.call('retrying in: 1'),
             mock.call('progress: 1/5'),
             mock.call('retrying in: 2'),
             mock.call('retrying in: 1'),
             mock.call('progress: 5/5'),
-            mock.call('Fetching result'),
-            mock.call('Downloading document test.json from test-collection/prediction'),
-            mock.call('Downloaded 10 bytes')
+            mock.call('fetching result'),
+            mock.call('downloaded 10 bytes')
         ])
 
     def test_feedback(self):
         api = ilabs_api.ILabsApi(_DUMMY_USER_KEY)
         datavault_api = ilabs_datavault_api.ILabsDatavaultApi(_DUMMY_USER_KEY, _DUMMY_DATAVAULT_TOKEN)
-        predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor(api, datavault_api, domain='foo-domain')
 
-        with mock.patch('ilabs.client.ilabs_datavault_api.ILabsDatavaultApi.upload') as upload:
-            predictor.upload_feedback(b'some contents', 'test-collection', 'test.json')
-            upload.assert_called_once_with(b'some contents', 'test-collection', 'test.json', facet='feedback')
+        predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor.init(
+            domain='foo-domain',
+            collection='test-collection',
+            user_key=_DUMMY_USER_KEY,
+            datavault_key=_DUMMY_DATAVAULT_TOKEN
+        )
+
+        predictor._datavault._request = mock.Mock()
+        predictor.upload(b'some contents', 'test.json', facet='feedback')
+        predictor._datavault._request.assert_called_once_with(
+            'POST', 'https://api.innodatalabs.com/datavault/test-collection/test.json/feedback',
+            b'some contents',
+            content_type='application/octet-stream',
+            query=None
+        )

--- a/ilabs/client/test/test_ilabs_datavault_predictor.py
+++ b/ilabs/client/test/test_ilabs_datavault_predictor.py
@@ -10,7 +10,7 @@ _DUMMY_DATAVAULT_TOKEN = 'JWT0123456789'
 class TestIlabsDatavaultPredictor(unittest.TestCase):
 
     def test_prediction(self):
-
+        ilabs_datavault_predictor.ILabsDatavaultPredictor._create_collection_if_needed = mock.Mock()
 
         predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor.init(
             domain='foo-domain',
@@ -48,8 +48,7 @@ class TestIlabsDatavaultPredictor(unittest.TestCase):
         ])
 
     def test_feedback(self):
-        api = ilabs_api.ILabsApi(_DUMMY_USER_KEY)
-        datavault_api = ilabs_datavault_api.ILabsDatavaultApi(_DUMMY_USER_KEY, _DUMMY_DATAVAULT_TOKEN)
+        ilabs_datavault_predictor.ILabsDatavaultPredictor._create_collection_if_needed = mock.Mock()
 
         predictor = ilabs_datavault_predictor.ILabsDatavaultPredictor.init(
             domain='foo-domain',


### PR DESCRIPTION
…d for redtag

Apparently I pushed ilabs.client==0.2.5 out without first committing to master. This code was lost when 0.2.6 was created from master branch.

Re-doing the same

@chinmaygadkari7 datavaultPredictor is now a sub-class of IlabsApi. Usage pattern have changed too. Please review and update the docs.